### PR TITLE
#17 Streamline apis

### DIFF
--- a/src/main/java/com/dorksquad/artwork/artwork/Artwork.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/Artwork.java
@@ -42,4 +42,11 @@ public class Artwork
         return this.image;
     }
 
+    public void setAlbum(String album) {
+        this.album = album;
+    }
+
+    public void setImage(Binary image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/com/dorksquad/artwork/artwork/ArtworkController.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/ArtworkController.java
@@ -3,10 +3,7 @@ package com.dorksquad.artwork.artwork;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -14,36 +11,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Controller
+@RequestMapping(value = "/artworks")
 public class ArtworkController {
 
     @Autowired
     private ArtworkService artworkService;
 
-    @GetMapping("/artworks")
-    public ResponseEntity<?> getArtworks(@RequestParam(required = false) String sort) {
-        List<Artwork> artworks;
-        if (sort != null) {
-            artworks = artworkService.getArtworks(sort);
-        } else {
-            artworks = artworkService.getArtworks();
-        }
-
+    @RequestMapping(method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<?> getArtworks(@RequestParam(required = false) String sort,
+                                         @RequestAttribute(name = "name", required = false) String name,
+                                         @RequestAttribute(name = "album", required = false) String album) {
+        List<Artwork> artworks = artworkService.getArtwork(sort, name, album);
         return ResponseEntity.ok(artworks);
     }
 
-    @GetMapping("/artworks/{name}")
-    public ResponseEntity<?> getArtworkByName(@PathVariable String name) {
-        Artwork artwork = artworkService.getArtworkByName(name);
-        return ResponseEntity.ok(artwork);
-    }
 
-    @GetMapping("/artworks/album/{album}")
-    public ResponseEntity<?> getArtworkByAlbum(@PathVariable String album) {
-        Artwork artwork = artworkService.getArtworkByAlbum(album);
-        return ResponseEntity.ok(artwork);
-    }
-
-    @PostMapping("/artworks/add")
+    @RequestMapping(method = RequestMethod.POST)
+    @ResponseBody
     public ResponseEntity<?> addArtwork(@RequestParam("name") String name,
                                         @RequestParam("album") String album,
                                         @RequestParam("image") MultipartFile image) throws IOException {

--- a/src/main/java/com/dorksquad/artwork/artwork/ArtworkController.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/ArtworkController.java
@@ -20,9 +20,9 @@ public class ArtworkController {
     @RequestMapping(method = RequestMethod.GET)
     @ResponseBody
     public ResponseEntity<?> getArtworks(@RequestParam(required = false) String sort,
-                                         @RequestAttribute(name = "name", required = false) String name,
-                                         @RequestAttribute(name = "album", required = false) String album) {
-        List<Artwork> artworks = artworkService.getArtwork(sort, name, album);
+                                         @RequestParam(required = false, name = "name") String name,
+                                         @RequestParam(name = "album", required = false) String album) {
+        List<Artwork> artworks = artworkService.getArtworks(sort, name, album);
         return ResponseEntity.ok(artworks);
     }
 
@@ -35,4 +35,23 @@ public class ArtworkController {
         String artwork = artworkService.addArtwork(name, album, image);
         return ResponseEntity.ok(artwork);
     }
+
+    @RequestMapping(method = RequestMethod.DELETE)
+    @ResponseBody
+    public ResponseEntity<?> deleteArtwork(@RequestParam("name") String name){
+        String result = artworkService.deleteArtwork(name);
+        return ResponseEntity.ok(result);
+    }
+
+
+    @RequestMapping(method = RequestMethod.PUT)
+    @ResponseBody
+    public ResponseEntity<?> updateArtwork(@RequestParam("name") String name,
+                                           @RequestParam(name = "album", required = false) String album,
+                                           @RequestParam(name = "image", required = false) MultipartFile image) throws IOException {
+        Artwork artwork = artworkService.updateArtwork(name, album,image);
+        return ResponseEntity.ok(artwork);
+    }
+
+
 }

--- a/src/main/java/com/dorksquad/artwork/artwork/ArtworkService.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/ArtworkService.java
@@ -31,33 +31,36 @@ public class ArtworkService {
         return artwork.getName();
     }
 
-    public List<Artwork> getArtwork(String sort,String name, String album){
-
+    public List<Artwork> getArtworks(String sort,String name, String album){
         if(name == null && album == null){
+
             return (sort == null) ? artworkRepo.findAll() : artworkRepo.findAll(Sort.by(sort).ascending());
         }
 
-
         List<Artwork> artworks = new ArrayList<>();
-
         artworks.add( (name != null) ? artworkRepo.findByName(name) : artworkRepo.findByAlbum(album));
 
         return artworks;
     }
 
-//    public Artwork getArtworkByName(String name) {
-//        return artworkRepo.findByName(name);
-//    }
-//
-//    public List<Artwork> getArtworks() {
-//        return artworkRepo.findAll();
-//    }
-//
-//    public List<Artwork> getArtworks(String sort) {
-//        return artworkRepo.findAll(Sort.by(sort).ascending());
-//    }
-//
-//    public Artwork getArtworkByAlbum(String album) {
-//        return artworkRepo.findByAlbum(album);
-//    }
+    public String deleteArtwork(String name){
+        if(artworkRepo.findByName(name) == null) return "Artwork with name "+name+" has not been found";
+
+        artworkRepo.deleteById(name);
+        return (artworkRepo.findByName(name) == null) ? "Artwork with name "+name+" has been successfully deleted" :
+                "Artwork with name "+name+" has not been deleted";
+    }
+
+    public Artwork updateArtwork(String name, String album, MultipartFile image) throws IOException{
+        Artwork artwork = artworkRepo.findByName(name);
+
+        if(album != null) artwork.setAlbum(album);
+        if(image != null){
+            Binary binaryFile = new Binary(BsonBinarySubType.BINARY, image.getBytes());
+            artwork.setImage(binaryFile);
+        }
+
+        artworkRepo.save(artwork);
+        return artwork;
+    }
 }

--- a/src/main/java/com/dorksquad/artwork/artwork/ArtworkService.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/ArtworkService.java
@@ -46,14 +46,14 @@ public class ArtworkService {
     public String deleteArtwork(String name){
         if(artworkRepo.findByName(name) == null) return "Artwork with name "+name+" has not been found";
 
-        artworkRepo.deleteById(name);
+        artworkRepo.delete(artworkRepo.findByName(name));
         return (artworkRepo.findByName(name) == null) ? "Artwork with name "+name+" has been successfully deleted" :
                 "Artwork with name "+name+" has not been deleted";
     }
 
     public Artwork updateArtwork(String name, String album, MultipartFile image) throws IOException{
         Artwork artwork = artworkRepo.findByName(name);
-
+        System.out.println(name +" "+album);
         if(album != null) artwork.setAlbum(album);
         if(image != null){
             Binary binaryFile = new Binary(BsonBinarySubType.BINARY, image.getBytes());

--- a/src/main/java/com/dorksquad/artwork/artwork/ArtworkService.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/ArtworkService.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -30,19 +31,33 @@ public class ArtworkService {
         return artwork.getName();
     }
 
-    public Artwork getArtworkByName(String name) {
-        return artworkRepo.findByName(name);
+    public List<Artwork> getArtwork(String sort,String name, String album){
+
+        if(name == null && album == null){
+            return (sort == null) ? artworkRepo.findAll() : artworkRepo.findAll(Sort.by(sort).ascending());
+        }
+
+
+        List<Artwork> artworks = new ArrayList<>();
+
+        artworks.add( (name != null) ? artworkRepo.findByName(name) : artworkRepo.findByAlbum(album));
+
+        return artworks;
     }
 
-    public List<Artwork> getArtworks() {
-        return artworkRepo.findAll();
-    }
-
-    public List<Artwork> getArtworks(String sort) {
-        return artworkRepo.findAll(Sort.by(sort).ascending());
-    }
-
-    public Artwork getArtworkByAlbum(String album) {
-        return artworkRepo.findByAlbum(album);
-    }
+//    public Artwork getArtworkByName(String name) {
+//        return artworkRepo.findByName(name);
+//    }
+//
+//    public List<Artwork> getArtworks() {
+//        return artworkRepo.findAll();
+//    }
+//
+//    public List<Artwork> getArtworks(String sort) {
+//        return artworkRepo.findAll(Sort.by(sort).ascending());
+//    }
+//
+//    public Artwork getArtworkByAlbum(String album) {
+//        return artworkRepo.findByAlbum(album);
+//    }
 }

--- a/src/main/java/com/dorksquad/artwork/artwork/IArtworkRepositoryMongo.java
+++ b/src/main/java/com/dorksquad/artwork/artwork/IArtworkRepositoryMongo.java
@@ -8,4 +8,5 @@ public interface IArtworkRepositoryMongo extends MongoRepository<Artwork, String
 
     Artwork findByAlbum(String album);
 
+
 }


### PR DESCRIPTION
This is my first open-source contribution.

I've took the issue #17 and implemented the following changes.

- Condensed all apis to just `/artworks` with 2 optional query parameters (name and album).
- Added CRUD operations to the `/artworks` api path.
- Bundled getArtworks() functions in Service Layer
- Added functions for Delete and Update methods in Service Layer

Kindly take a look at my code and provide feedback.

Also, I'm working on the test cases.

Thanks :)